### PR TITLE
Attempt to fix nginx retart error

### DIFF
--- a/.ebextensions/proxy.config
+++ b/.ebextensions/proxy.config
@@ -46,7 +46,7 @@ files:
     group: root
     content: |
       #!/bin/bash -xe
-      rm -f /etc/nginx/conf.d/00_elastic_beanstalk_proxy.conf
+      if [ -f /etc/nginx/conf.d/00_elastic_beanstalk_proxy.conf ]; then rm -f /etc/nginx/conf.d/00_elastic_beanstalk_proxy.conf; fi
       service nginx stop
       service nginx start
 


### PR DESCRIPTION
AWS support says that the script is trying to delete a file that
that doesn't exist.  Their suggestion is to ddd some logic to only delete
if file exists.