### PR TITLE
another attempt to fix nginx restart

### DIFF
--- a/.ebextensions/proxy.config
+++ b/.ebextensions/proxy.config
@@ -47,8 +47,10 @@ files:
     content: |
       #!/bin/bash -xe
       if [ -f /etc/nginx/conf.d/00_elastic_beanstalk_proxy.conf ]; then rm -f /etc/nginx/conf.d/00_elastic_beanstalk_proxy.conf; fi
-      service nginx stop
-      service nginx start
+          echo 'Stopping Nginx......'
+      initctl nginx stop
+          echo 'Starting Nginx...... '
+      initctl nginx start
 
 container_commands:
  removeconfig:


### PR DESCRIPTION
This time AWS support suggests using initctl instead of service
command.

FROM AWS SUPPORT:
 I have done some research on the issue and have found that it is an
 ongoing issue with the node.js environment and the cause for the issue
 all node.js environment greater than equal to 4.4.6 version is
 reporting an error in service nginx restart.  I have found that instead
 of service command they are now using the initctl for starting and
 stopping the nginx service.