### PR TITLE
Add git sha to agora version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,12 +34,14 @@ jobs:
       script: npm run ci:travis
       node_js: 8
     - stage: eb-deploy
-      script: git archive -v -o agora-app.zip --format=zip HEAD
+      script:
+        - ./set-agora-version.sh || travis_terminate 1
+        - zip /tmp/agora-app.zip -r * .[^.]*
       deploy:
         - provider: elasticbeanstalk
           skip_cleanup: true
           bucket_name: org-sagebionetworks-agora-deployment-agora-$TRAVIS_BRANCH
-          zip_file: agora-app.zip
+          zip_file: /tmp/agora-app.zip
           region: us-east-1
           app: agora-ampad
           env:

--- a/set-agora-version.sh
+++ b/set-agora-version.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+
+# Add the git short sha to the agora version
+GIT_SHORT_SHA=$(git rev-parse --short HEAD)
+VERSION=$(jq -r '.["version"]' ./package.json | sed 's/-.*//g')
+AGORA_VERSION=$VERSION-$GIT_SHORT_SHA
+echo "AGORA_VERSION=$AGORA_VERSION"
+jq -r ".[\"version\"] = \"$AGORA_VERSION\"" ./package.json > ./new-package.json
+mv -f new-package.json package.json


### PR DESCRIPTION
The agora version is statically defined in the package.json file.
Showing version as 1.0.0 is not enough information for us to track
down the actual commit that was deployed. We now set to
`<version>-<git sha>`, something like 1.0.0-a5e76c3, so we know the
exact commit that is deployed.

Fixes: https://github.com/Sage-Bionetworks/Agora/issues/560