### PR TITLE
disable logging for zip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ jobs:
     - stage: eb-deploy
       script:
         - ./set-agora-version.sh || travis_terminate 1
-        - zip /tmp/agora-app.zip -r * .[^.]*
+        - zip /tmp/agora-app.zip -qr * .[^.]*
       deploy:
         - provider: elasticbeanstalk
           skip_cleanup: true


### PR DESCRIPTION
Travis logs only loads 10K lines on their web site.  Showing logs
zip command will generate over that many thereby cutting off the
logs for the deploymebt.  We set the quite flag to supress zip
log so we can see logs for the deploy to AWS step.