### PR TITLE
Remove NodeVersion setting

### DIFF
--- a/.ebextensions/eb-options.config
+++ b/.ebextensions/eb-options.config
@@ -2,4 +2,3 @@ option_settings:
   aws:elasticbeanstalk:container:nodejs:
     ProxyServer: "nginx"
     NodeCommand: "node --max_old_space_size=2000  ./dist/server.js"
-    NodeVersion: "8.11.4"


### PR DESCRIPTION
We need to remove NodeVersion setting from the app bundle otherwise
it may conflict with the beanstalk solution stack setting[1] in
Sage-Bionetworks/Agora repo.

[1] https://github.com/Sage-Bionetworks/Agora-infra/blob/develop/config/prod/agora.yaml#L16