### PR TITLE
AG-135: bump data version because json data field name updated

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "agora",
   "version": "2.1.1",
   "data-file": "syn13363290",
-  "data-version": "18",
+  "data-version": "19",
   "description": "An application to aggregate genomic evidence supporting candidate gene and module targets nominated by members of the AMP-AD consortium.",
   "keywords": [
     "angular8",


### PR DESCRIPTION
`validation study details` changed to `validation_study_details`