### PR TITLE
AG-165: silence progress outputs

### DIFF
--- a/config/webpack.prod.js
+++ b/config/webpack.prod.js
@@ -168,6 +168,13 @@ module.exports = function (env) {
       clearImmediate: false,
       setImmediate: false,
       fs: 'empty'
-    }
+    },
+
+    /**
+     * Only output errors and warnings in log to prevent exceeding the maximum log length error
+     * https://webpack.js.org/configuration/stats/
+    */
+    stats: 'errors-warnings'
+
   });
 }


### PR DESCRIPTION
To prevent `The job exceeded the maximum log length, and has been terminated.` error during prod build.