### PR TITLE
AG-165: Change timeout for env update

### DIFF
--- a/.ebextensions/eb-options.config
+++ b/.ebextensions/eb-options.config
@@ -3,3 +3,6 @@ option_settings:
     ProxyServer: "nginx"
     NodeCommand: "node --max_old_space_size=2000  ./dist/server.js"
     NodeVersion: "12.14.1"
+
+  aws:elasticbeanstalk:command:
+    Timeout: 1200


### PR DESCRIPTION
@xschildw was unable to update the Beanstalk deployment timeout from agora-infra. We will update this setting within the Agora app instead. 

AWS Docs: 
[https://github.com/awsdocs/elastic-beanstalk-samples/blob/master/configuration-files/aws-provided/environment-configuration/timeout-commands.config](https://github.com/awsdocs/elastic-beanstalk-samples/blob/master/configuration-files/aws-provided/environment-configuration/timeout-commands.config)

[https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/ebextensions.html](https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/ebextensions.html)

[https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/ebextensions-optionsettings.html](https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/ebextensions-optionsettings.html)