### PR TITLE
Remove unsupported settings

### DIFF
--- a/.ebextensions/eb-options.config
+++ b/.ebextensions/eb-options.config
@@ -1,8 +1,3 @@
 option_settings:
   aws:elasticbeanstalk:container:nodejs:
     ProxyServer: "nginx"
-    NodeCommand: "node --max_old_space_size=2000  ./dist/server.js"
-    NodeVersion: "12.14.1"
-
-  aws:elasticbeanstalk:command:
-    Timeout: 2700


### PR DESCRIPTION
Remove unsupported settings for EBS node.js server based on what is documented here: https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/command-options-specific.html#command-options-nodejs