### PR TITLE
AG-292: Improve table sort, display, and export

### DIFF
--- a/src/app/genes/gene-overview/gene-overview.component.ts
+++ b/src/app/genes/gene-overview/gene-overview.component.ts
@@ -466,7 +466,7 @@ export class GeneOverviewComponent implements OnInit, OnDestroy, AfterContentChe
     }
 
     getAlias(): string {
-        if (this.geneInfo.alias.length > 0) {
+        if (this.geneInfo.alias && this.geneInfo.alias.length > 0) {
             return this.geneInfo.alias.join(', ');
         }
         return '';

--- a/src/app/genes/gene-similar/gene-similar.component.html
+++ b/src/app/genes/gene-similar/gene-similar.component.html
@@ -75,7 +75,7 @@
         <ng-template pTemplate="body" let-rowData let-columns="columns">
             <tr [pSelectableRow]="rowData">
                 <td *ngFor="let col of columns">
-                    {{colFinalValue(rowData, col.field, col.subfield)}}
+                    {{colFinalValue(rowData, col.field)}}
                 </td>
             </tr>
         </ng-template>

--- a/src/app/genes/genes-list/genes-list.component.html
+++ b/src/app/genes/genes-list/genes-list.component.html
@@ -116,7 +116,7 @@
             </tr>
         </ng-template>
         <ng-template pTemplate="body" let-rowData let-columns="columns">
-            <tr [pSelectableRow]="rowData" tabindex="0">
+            <tr [pSelectableRow]="rowData">
                 <td *ngFor="let col of columns">
                     {{rowData[col.field]}}
                 </td>

--- a/src/app/genes/genes-list/genes-list.component.ts
+++ b/src/app/genes/genes-list/genes-list.component.ts
@@ -32,6 +32,7 @@ export class GenesListComponent implements OnInit {
     cols: any[];
     selectedColumns: any[];
     loading: boolean = true;
+    noValue = 'No value';
 
     constructor(
         private navService: NavigationService,
@@ -44,15 +45,15 @@ export class GenesListComponent implements OnInit {
         this.cols = [
             { field: 'hgnc_symbol', header: 'Gene Symbol'},
             { field: 'nominations', header: 'Nominations' },
-            { field: 'initial_nomination', header: 'Year First Nominated' },
-            { field: 'teams', header: 'Nominating Teams' },
-            { field: 'study', header: 'Cohort Study' },
-            { field: 'input_data', header: 'Input Data' },
-            { field: 'pharos_class', header: 'Pharos Class' },
-            { field: 'classification', header: 'Small Molecule Druggability' },
-            { field: 'safety_bucket_definition', header: 'Safety Rating' },
-            { field: 'abability_bucket_definition', header: 'Antibody Modality' },
-            { field: 'validation_study_details', header: 'Experimental Validation' },
+            { field: 'initial_nomination_display_value', header: 'Year First Nominated' },
+            { field: 'teams_display_value', header: 'Nominating Teams' },
+            { field: 'study_display_value', header: 'Cohort Study' },
+            { field: 'input_data_display_value', header: 'Input Data' },
+            { field: 'pharos_class_display_value', header: 'Pharos Class' },
+            { field: 'sm_druggability_display_value', header: 'Small Molecule Druggability' },
+            { field: 'safety_rating_display_value', header: 'Safety Rating' },
+            { field: 'ab_modality_display_value', header: 'Antibody Modality' },
+            { field: 'validation_study_details_display_value', header: 'Experimental Validation' },
         ];
 
         // Add a position property so we can add/remove at the same position
@@ -90,8 +91,8 @@ export class GenesListComponent implements OnInit {
                 let validationStudyDetailsArray = [];
                 let initialNominationArray = [];
 
+                // Handle NominatedTargets fields
                 // First map all entries nested in the data to a new array
-
                 if (de.nominatedtarget.length) {
                     teamsArray = de.nominatedtarget.map((nt: NominatedTarget) => nt.team);
                     studyArray = de.nominatedtarget.map((nt: NominatedTarget) => nt.study);
@@ -110,54 +111,38 @@ export class GenesListComponent implements OnInit {
                 studyArray = this.commaFlattenArray(studyArray);
                 inputDataArray = this.commaFlattenArray(inputDataArray);
 
-                // Join the final strings into a new array removing duplicates
-                de.teams = (teamsArray.length) ? teamsArray.filter(this.getUnique)
+                // Populate NominatedTargets display fields
+                de.teams_display_value = (teamsArray.length) ? teamsArray.filter(this.getUnique)
                     .sort((a: string, b: string) => a.localeCompare(b)).join(', ') : '';
-                de.study = (studyArray.length) ? studyArray.filter(this.getUnique)
+                de.study_display_value = (studyArray.length) ? studyArray.filter(this.getUnique)
                     .sort((a: string, b: string) => a.localeCompare(b)).join(', ') : '';
-                de.input_data = (inputDataArray.length) ? inputDataArray.filter(this.getUnique)
+                de.input_data_display_value = (inputDataArray.length) ? inputDataArray.filter(this.getUnique)
                     .sort((a: string, b: string) => a.localeCompare(b)).join(', ') : '';
-                de.validation_study_details = (validationStudyDetailsArray.length) ?
+                de.validation_study_details_display_value = (validationStudyDetailsArray.length) ?
                     [...new Set(validationStudyDetailsArray)]
                     .sort((a: string, b: string) => a.localeCompare(b)).join(', ') : '';
-                de.initial_nomination = (initialNominationArray.length) ?
+                de.initial_nomination_display_value = (initialNominationArray.length) ?
                     Math.min(...initialNominationArray) : undefined;
 
-                // Druggability columns
-                const noValue = 'No value';
+                // Populate Druggability display fields
                 if (de.druggability && de.druggability.length) {
-                    de.sm_druggability_bucket =
-                        de.druggability[0].sm_druggability_bucket.toString();
-                    de.safety_bucket = de.druggability[0].safety_bucket.toString();
-                    de.abability_bucket = de.druggability[0].abability_bucket.toString();
-                    de.pharos_class = de.druggability[0].pharos_class ? de.druggability[0].pharos_class : noValue;
-                    de.classification = de.druggability[0].sm_druggability_bucket + ': ' +
+                    de.pharos_class_display_value = de.druggability[0].pharos_class ?
+                        de.druggability[0].pharos_class : this.noValue;
+                    de.sm_druggability_display_value = de.druggability[0].sm_druggability_bucket + ': ' +
                         de.druggability[0].classification;
-                    de.safety_bucket_definition = de.druggability[0].safety_bucket + ': ' +
+                    de.safety_rating_display_value = de.druggability[0].safety_bucket + ': ' +
                         de.druggability[0].safety_bucket_definition;
-                    de.abability_bucket_definition = de.druggability[0].abability_bucket + ': ' +
+                    de.ab_modality_display_value = de.druggability[0].abability_bucket + ': ' +
                         de.druggability[0].abability_bucket_definition;
                 } else {
-                    de.sm_druggability_bucket = noValue;
-                    de.safety_bucket = noValue;
-                    de.abability_bucket = noValue;
-                    de.pharos_class = noValue;
-                    de.classification = noValue;
-                    de.safety_bucket_definition = noValue;
-                    de.abability_bucket_definition = noValue;
+                    de.pharos_class_display_value = this.noValue;
+                    de.sm_druggability_display_value = this.noValue;
+                    de.safety_rating_display_value = this.noValue;
+                    de.ab_modality_display_value = this.noValue;
                 }
             });
             this.genesInfo = this.dataSource;
             this.totalRecords = (data.totalRecords) ? data.totalRecords : 0;
-
-            // Starts table with the nominations columns sorted in descending order
-            this.customSort({
-                data: this.dataSource,
-                field: 'nominations',
-                mode: 'single',
-                order: -1
-            } as SortEvent);
-
             this.loading = false;
         });
     }
@@ -195,13 +180,18 @@ export class GenesListComponent implements OnInit {
     downloadTable() {
         const downloadArray = [];
         // The headers row for the csv file
-        downloadArray[0] = this.cols.map((c) => c.field).join();
+        downloadArray[0] = this.cols.map((c) => c.header).join();
+        // Columns with values containing commas
+        const escapeFields = ['teams_display_value',  'study_display_value', 'input_data_display_value',
+            'sm_druggability_display_value', 'safety_rating_display_value',
+            'ab_modality_display_value', 'validation_study_details_display_value'];
+
         this.dataSource.forEach((de: GeneInfo) => {
             downloadArray.push('');
             this.cols.forEach((c, index) => {
-                downloadArray[downloadArray.length - 1] += (c.field === 'hgnc_symbol' || c.field ===
-                'nominations' || c.field === 'pharos_class') ? de[c.field] :
-                    ('"' + de[c.field] + '"');
+                downloadArray[downloadArray.length - 1] +=
+                    // quote the values that contain commas
+                    (escapeFields.includes(c.field)) ?  ('"' + de[c.field] + '"') : de[c.field];
                 downloadArray[downloadArray.length - 1] += ((index) < (this.cols.length - 1)) ?
                     ',' : '';
             });
@@ -308,13 +298,9 @@ export class GenesListComponent implements OnInit {
 
     customSort(event: SortEvent) {
         event.data.sort((data1, data2) => {
-            const value1 = (Array.isArray(data1[event.field])) ?
-                data1[event.field].map((nt) => nt.team).join(', ') :
-                data1[event.field];
-            const value2 = (Array.isArray(data2[event.field])) ?
-                data2[event.field].map((nt) => nt.team).join(', ') :
-                data2[event.field];
             let result = null;
+            const value1 = data1[event.field];
+            const value2 = data2[event.field];
 
             if (value1 == null && value2 != null) {
                 result = -1;
@@ -323,7 +309,16 @@ export class GenesListComponent implements OnInit {
             } else if (value1 == null && value2 == null) {
                 result = 0;
             } else if (typeof value1 === 'string' && typeof value2 === 'string') {
-                result = value1.localeCompare(value2);
+                // Natural sorting for this score type, which can be >= 10
+                if (event.field === 'sm_druggability_display_value') {
+                    const numericValue1 = parseInt(value1.split(':')[0], 10);
+                    const numericValue2 = parseInt(value2.split(':')[0], 10);
+                    if (!isNaN(numericValue1) && !isNaN(numericValue2)) {
+                        result = (numericValue1 < numericValue2) ? -1 : (numericValue1 > numericValue2) ? 1 : 0;
+                    }
+                } else {
+                    result = value1.localeCompare(value2);
+                }
             } else {
                 result = (value1 < value2) ? -1 : (value1 > value2) ? 1 : 0;
             }

--- a/src/app/models/geneInfo.ts
+++ b/src/app/models/geneInfo.ts
@@ -12,32 +12,27 @@ export interface GeneInfo {
     isIGAP: boolean;
     haseqtl: boolean;
     isChangedInADBrain: boolean;
+    isAnyRNAChangedInADBrain?: boolean;
+    isAnyProteinChangedInADBrain?: boolean;
     medianexpression: MedianExpression[];
     nominatedtarget: NominatedTarget[];
     nominations: number;
-    // Extra field for the genes list table. This will be
-    // all the teams in a single string separated by commas
-    teams?: string;
-    study?: string;
-    input_data?: string;
-    validation_study_details?: string;
-    initial_nomination?: number;
-    sm_druggability_bucket?: string;
-    safety_bucket?: string;
-    feasibility_bucket?: string;
-    abability_bucket?: string;
-    new_modality_bucket?: string;
-    tissue_engagement_bucket?: string;
-    pharos_class?: string;
-    classification?: string;
-    safety_bucket_definition?: string;
-    feasibility_bucket_definition?: string;
-    abability_bucket_definition?: string;
-    new_modality_bucket_definition?: string;
-    brain_regions?: string;
-    num_brain_regions?: string;
-    isAnyRNAChangedInADBrain?: boolean;
-    isAnyProteinChangedInADBrain?: boolean;
+    // Extra fields for display values
+    // NominatedTargets
+    teams_display_value?: string;
+    study_display_value?: string;
+    input_data_display_value?: string;
+    validation_study_details_display_value?: string;
+    initial_nomination_display_value?: number;
+    nominated_target_display_value?: boolean;
+    // MedianExpression
+    brain_regions_display_value?: string;
+    num_brain_regions_display_value?: string;
+    // Druggability
+    pharos_class_display_value?: string;
+    sm_druggability_display_value?: string;
+    safety_rating_display_value?: string;
+    ab_modality_display_value?: string;
 }
 
 export interface MedianExpression {


### PR DESCRIPTION
* Fix similar genes table's druggability column sorts
* Export CSVs with column display names rather than raw field names
* Similar genes table's Nominated Target column no longer displays mixed types
* Prune and rename GeneInfo display fields
* Set consistent default display values for missing table data
* Fix display issue with missing alias[] in overview
