### PR TITLE
AG-256 - Changed how height is calculated for related genes "hairball" graph

### DIFF
--- a/src/app/charts/force-chart/force-chart-view/force-chart-view.component.ts
+++ b/src/app/charts/force-chart/force-chart-view/force-chart-view.component.ts
@@ -85,8 +85,7 @@ export class ForceChartViewComponent implements OnInit, AfterViewInit, OnChanges
     ngAfterViewInit() {
         setTimeout(() => {
             this.width = this.forceChart.nativeElement.parentElement.offsetWidth - 30;
-            const geneColNode = d3.select('.current-gene-col').node() as HTMLBaseElement;
-            this.height = (geneColNode) ? geneColNode.getBoundingClientRect().height : 400;
+            this.height = 400 + (700 * (this.networkData.nodes.length / 100));
             this.loaded = true;
             this.simulation = d3.forceSimulation<GeneNode, GeneLink>()
                 .force('charge', (d) => {

--- a/src/app/genes/gene-overview/evidence-menu/rna/gene-network/gene-network.component.scss
+++ b/src/app/genes/gene-overview/evidence-menu/rna/gene-network/gene-network.component.scss
@@ -33,16 +33,11 @@
     padding-bottom: 45px;
 
     .force-chart-container {
-        height: 1173px;
         background: $faded-grey-background;
 
         force-chart {
             width: 100%;
             height: 100%;
-        }
-
-        svg {
-            height: 1173px;
         }
     }
 }


### PR DESCRIPTION
Instead of setting the height depending on the right column, the height is calculated depending on the number of nodes with a minimum of 400. This should make the "hairball" centered in all cases.