### PR TITLE
revert breaking dependabot change

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29411,6 +29411,11 @@
           "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
           "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
         },
+        "path-parse": {
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+          "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
+        },
         "pify": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",


### PR DESCRIPTION
I thought this dependabot update broke deployment since develop was returning 502s and Elastic Beanstalk status went to severe...but apparently that's just how our dev deployments go sometimes as it healed itself before this PR passed the embedded checks...closing this as no need to revert.