### PR TITLE
Load teamInfo values by team name rather than by expVal report index

### DIFF
--- a/src/app/genes/gene-overview/exp-validation/exp-validation.component.html
+++ b/src/app/genes/gene-overview/exp-validation/exp-validation.component.html
@@ -12,8 +12,12 @@
             <h1 class="inner-section-divider"></h1>
         </div>
         <div class="section-thin no-padding-top overview-sections">
-            <h2>{{getTeamInfoField(d.team, "program")}} : {{getTeamInfoField(d.team, "team_full")}}</h2>
-            <p class="col-8 section-desc">{{getTeamInfoField(d.team, "description")}}</p>
+            <div *ngFor="let t of teamInfo;">
+                <div *ngIf="t.team === d.team ">
+                    <h2>{{t.program}} : {{t.team_full}}</h2>
+                    <p class="col-8 section-desc">{{t.description}}</p>
+                </div>
+            </div>
             <h4>Hypothesis Being Tested</h4>
             <p class="col-8 section-desc">{{d.hypothesis_tested}}</p>
             <h4>Species and Model System</h4>

--- a/src/app/genes/gene-overview/exp-validation/exp-validation.component.html
+++ b/src/app/genes/gene-overview/exp-validation/exp-validation.component.html
@@ -12,8 +12,8 @@
             <h1 class="inner-section-divider"></h1>
         </div>
         <div class="section-thin no-padding-top overview-sections">
-            <h2>{{teamInfo[i].program}}: {{teamInfo[i].team_full}}</h2>
-            <p class="col-8 section-desc">{{teamInfo[i].description}}</p>
+            <h2>{{getTeamInfoField(d.team, "program")}} : {{getTeamInfoField(d.team, "team_full")}}</h2>
+            <p class="col-8 section-desc">{{getTeamInfoField(d.team, "description")}}</p>
             <h4>Hypothesis Being Tested</h4>
             <p class="col-8 section-desc">{{d.hypothesis_tested}}</p>
             <h4>Species and Model System</h4>

--- a/src/app/genes/gene-overview/exp-validation/exp-validation.component.ts
+++ b/src/app/genes/gene-overview/exp-validation/exp-validation.component.ts
@@ -32,4 +32,9 @@ export class ExpValidationComponent implements OnInit {
             this.teamInfo = teams;
         });
     }
+
+    getTeamInfoField(teamName: string, field: string) {
+        const team = this.teamInfo.find(t => t.team === teamName);
+        return team[field];
+    }
 }

--- a/src/app/genes/gene-overview/exp-validation/exp-validation.component.ts
+++ b/src/app/genes/gene-overview/exp-validation/exp-validation.component.ts
@@ -32,9 +32,4 @@ export class ExpValidationComponent implements OnInit {
             this.teamInfo = teams;
         });
     }
-
-    getTeamInfoField(teamName: string, field: string) {
-        const team = this.teamInfo.find(t => t.team === teamName);
-        return team[field];
-    }
 }


### PR DESCRIPTION
Loading teamInfo values by expVal index fails when a gene has multiple expVal reports submitted by the same team. 