### PR TITLE
Adapt viewNomProcess to the modified data_synapseid structure

### DIFF
--- a/src/app/genes/gene-overview/nom-details/nom-details.component.ts
+++ b/src/app/genes/gene-overview/nom-details/nom-details.component.ts
@@ -78,7 +78,7 @@ export class NominationDetailsComponent implements OnInit {
 
     viewNomProcess(index: number) {
         window.open('https://adknowledgeportal.synapse.org/Explore/Studies/DetailsPage?Study=' +
-            this.ntInfoArray[index].data_synapseid[0], '_blank');
+            this.ntInfoArray[index].data_synapseid, '_blank');
     }
 
     toTitleCase(index: number, field: string): string {

--- a/src/app/models/geneInfo.ts
+++ b/src/app/models/geneInfo.ts
@@ -50,7 +50,7 @@ export interface NominatedTarget {
     target_choice_justification: string;
     predicted_therapeutic_direction: string;
     data_used_to_support_target_selection: string;
-    data_synapseid: string[];
+    data_synapseid: string;
     study: string;
     input_data: string;
     validation_study_details: string;

--- a/src/app/testing/gene-mocks.ts
+++ b/src/app/testing/gene-mocks.ts
@@ -121,7 +121,7 @@ export const mockInfo1: GeneInfo = {
       data_used_to_support_target_selection:
         'Discovery quantitative proteomics of ' +
         'FrCx \nWPCNA of multiple and consensus cohorts\nANOVA',
-      data_synapseid: ['syn3606086', 'syn5759376', 'syn7170616'],
+      data_synapseid: 'syn3606086',
       study: 'ACT, BLSA, Banner',
       input_data: 'Protein',
       validation_study_details: '',


### PR DESCRIPTION
The data field was a list, now it's a single value. Note that we never had multiple values in this field when it was a list, and that the only place the field is used in the app is the one modified by this PR.