### PR TITLE
Update travis ci distro

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: required
-dist: xenial
+dist: focal
 language: node_js
 cache:
   npm: false


### PR DESCRIPTION
This is an attempt to update aws-sdk to v3 and resolve this
error..

```
Installing deploy dependencies
Version 2 of the Ruby SDK will enter maintenance mode as of November 20, 2020.
To continue receiving service updates and new features, please upgrade to Version 3.
More information can be found here:
https://aws.amazon.com/blogs/developer/deprecation-schedule-for-aws-sdk-for-ruby-v2/
```