### PR TITLE
Update travis ci providers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,8 @@ jobs:
       node_js: 16
       deploy:
         - provider: elasticbeanstalk
-          skip_cleanup: true
+          edge: true
+          cleanup: true
           bucket_name: org-sagebase-agora-deployment-agora-$TRAVIS_BRANCH
           zip_file: /tmp/agora-app.zip
           region: us-east-1
@@ -67,7 +68,8 @@ jobs:
       node_js: 16
       deploy:
         - provider: elasticbeanstalk
-          skip_cleanup: true
+          edge: true
+          cleanup: true
           bucket_name: org-sagebase-agora-deployment-agora-$TRAVIS_BRANCH
           zip_file: /tmp/agora-app.zip
           region: us-east-1
@@ -88,7 +90,8 @@ jobs:
       node_js: 16
       deploy:
         - provider: elasticbeanstalk
-          skip_cleanup: true
+          edge: true
+          cleanup: true
           bucket_name: org-sagebase-agora-deployment-agora-$TRAVIS_BRANCH
           zip_file: /tmp/agora-app.zip
           region: us-east-1


### PR DESCRIPTION
This is to update the travis providers to use dpl[1] ver 2.  The default is
ver 1 and it is not able to decrypt secrets causing the beanstalk
provider to fail deployments.

[1] https://blog.travis-ci.com/2019-08-27-deployment-tooling-dpl-v2-preview-release