### PR TITLE
AG-831: Update y-axis break handling to work with unsorted distributions

### DIFF
--- a/src/app/features/charts/components/score-chart/score-chart.component.ts
+++ b/src/app/features/charts/components/score-chart/score-chart.component.ts
@@ -88,8 +88,11 @@ export class ScoreChartComponent extends BaseChartComponent {
     });
   }
 
-  getMinDiff(count: number, distribution: any[]) {
-    const min = Math.min(...distribution.map(d => count - d.value).filter(v => v > 0));
+  // Returns the smallest positive difference between the provided
+  // bucket value and all other bucket values in the distribution
+  getMinDiff(value: number, distribution: any[]) {
+    let arr = distribution.map(d => value - d.value).filter(v => v > 0)
+    const min = Math.min(...arr);
     return min === Infinity ? 0 : min;
   }
 

--- a/src/app/features/charts/components/score-chart/score-chart.component.ts
+++ b/src/app/features/charts/components/score-chart/score-chart.component.ts
@@ -67,20 +67,17 @@ export class ScoreChartComponent extends BaseChartComponent {
         this.scoreIndex = i;
       }
 
-      if (i < 1 && !this.break.origin) {
-        const nextItem = this.distribution[i + 1] || {};
-        const diff = item.value - (nextItem.value || 0);
+      // Introduce a y-axis break if this bar is huge relative to other bars
+      const minDiff = this.getMinDiff(item.value, this.distribution);
+      if (minDiff > 2000) {
+            this.break = {
+              index: i,
+              upper: Math.floor(item.value / 1000) * 1000,
+              lower: Math.ceil((item.value - minDiff) / 1000) * 1000 + 1000,
+            };
 
-        if (diff > 2000) {
-          this.break = {
-            index: i,
-            upper: Math.floor(item.value / 1000) * 1000,
-            lower: Math.ceil(nextItem.value / 1000) * 1000 + 1000,
-          };
-
-          this.distribution[i].truncated =
-            this.break.lower + (item.value - this.break.upper);
-        }
+            this.distribution[i].truncated =
+              this.break.lower + (item.value - this.break.upper);
       }
     });
 
@@ -89,6 +86,11 @@ export class ScoreChartComponent extends BaseChartComponent {
     this.group = this.dimension.group().reduceSum((d: any) => {
       return d.truncated || d.value;
     });
+  }
+
+  getMinDiff(count: number, distribution: any[]) {
+    const min = Math.min(...distribution.map(d => count - d.value).filter(v => v > 0));
+    return min === Infinity ? 0 : min;
   }
 
   initChart() {

--- a/src/app/features/charts/components/score-chart/score-chart.component.ts
+++ b/src/app/features/charts/components/score-chart/score-chart.component.ts
@@ -70,14 +70,14 @@ export class ScoreChartComponent extends BaseChartComponent {
       // Introduce a y-axis break if this bar is huge relative to other bars
       const minDiff = this.getMinDiff(item.value, this.distribution);
       if (minDiff > 2000) {
-            this.break = {
-              index: i,
-              upper: Math.floor(item.value / 1000) * 1000,
-              lower: Math.ceil((item.value - minDiff) / 1000) * 1000 + 1000,
-            };
+        this.break = {
+          index: i,
+          upper: Math.floor(item.value / 1000) * 1000,
+          lower: Math.ceil((item.value - minDiff) / 1000) * 1000 + 1000,
+        };
 
-            this.distribution[i].truncated =
-              this.break.lower + (item.value - this.break.upper);
+        this.distribution[i].truncated =
+          this.break.lower + (item.value - this.break.upper);
       }
     });
 

--- a/src/app/features/charts/components/score-chart/score-chart.component.ts
+++ b/src/app/features/charts/components/score-chart/score-chart.component.ts
@@ -91,7 +91,7 @@ export class ScoreChartComponent extends BaseChartComponent {
   // Returns the smallest positive difference between the provided
   // bucket value and all other bucket values in the distribution
   getMinDiff(value: number, distribution: any[]) {
-    let arr = distribution.map(d => value - d.value).filter(v => v > 0)
+    const arr = distribution.map(d => value - d.value).filter(v => v > 0);
     const min = Math.min(...arr);
     return min === Infinity ? 0 : min;
   }


### PR DESCRIPTION
The previous logic only compared each value to the next value. This logic worked fine when our values in the underlying data were accidentally sorted in descending order, but once the data was corrected to return the values in the correct order for their associated bins, that logic broke.