### PR TITLE
AG-834: Handle legacy Agora URL redirects

### DIFF
--- a/src/app/app.custom-uri-serializer.ts
+++ b/src/app/app.custom-uri-serializer.ts
@@ -1,0 +1,18 @@
+import {UrlSerializer, UrlTree, DefaultUrlSerializer} from '@angular/router';
+
+// CustomUrlSerializer strips parentheses from legacy Agora URLs
+// before parsing; this prevents legacy path parts (e.g. (genes-router:genes-list)
+// from being stripped before Angular route handling.
+export class CustomUrlSerializer implements UrlSerializer {
+  parse(url: any): UrlTree {
+    let dus = new DefaultUrlSerializer();
+    url = url.replace('(','').replace(')','');
+    return dus.parse(url);
+  }
+
+  serialize(tree: UrlTree): any {
+    let dus = new DefaultUrlSerializer();
+    return dus.serialize(tree);
+  }
+}
+

--- a/src/app/app.custom-uri-serializer.ts
+++ b/src/app/app.custom-uri-serializer.ts
@@ -5,13 +5,13 @@ import {UrlSerializer, UrlTree, DefaultUrlSerializer} from '@angular/router';
 // from being stripped before Angular route handling.
 export class CustomUrlSerializer implements UrlSerializer {
   parse(url: any): UrlTree {
-    let dus = new DefaultUrlSerializer();
+    const dus = new DefaultUrlSerializer();
     url = url.replace('(','').replace(')','');
     return dus.parse(url);
   }
 
   serialize(tree: UrlTree): any {
-    let dus = new DefaultUrlSerializer();
+    const dus = new DefaultUrlSerializer();
     return dus.serialize(tree);
   }
 }

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -4,6 +4,7 @@
 import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import {UrlSerializer} from '@angular/router';
 import { CookieService } from 'ngx-cookie-service';
 import {
   NgxGoogleAnalyticsModule,
@@ -21,6 +22,7 @@ import { GenesModule } from './features/genes';
 import { ChartsModule } from './features/charts';
 import { TeamsModule } from './features/teams';
 import { AppRoutingModule } from './app.routing';
+import {CustomUrlSerializer} from './app.custom-uri-serializer';
 
 // -------------------------------------------------------------------------- //
 // Components
@@ -41,13 +43,17 @@ import { AppComponent } from './app.component';
     ChartsModule,
     TeamsModule,
 
-    // Rounting
+    // Routing
     AppRoutingModule,
 
     NgxGoogleAnalyticsModule.forRoot(environment.ga),
     NgxGoogleAnalyticsRouterModule,
   ],
-  providers: [CookieService, { provide: APP_BASE_HREF, useValue: '/' }],
+  providers: [
+    CookieService,
+    { provide: APP_BASE_HREF, useValue: '/' },
+    { provide: UrlSerializer, useClass: CustomUrlSerializer }
+  ],
   bootstrap: [AppComponent],
 })
 export class AppModule {}

--- a/src/app/app.routing.ts
+++ b/src/app/app.routing.ts
@@ -22,6 +22,8 @@ export const routes: Routes = [
 
   { path: 'genes/comparison', component: GeneComparisonToolComponent },
   { path: 'genes/nominated-targets', component: GeneNominatedTargetsComponent },
+  { path: 'genes/genes-router:genes-list', redirectTo: 'genes/nominated-targets', pathMatch: 'full' },
+  { path: 'genes/genes-router:gene-details/:id', redirectTo: 'genes/:id', pathMatch: 'full' },
   { path: 'genes/:id/similar', component: GeneSimilarComponent },
   { path: 'genes/:id/:tab/:subtab', component: GeneDetailsComponent },
   { path: 'genes/:id/:tab', component: GeneDetailsComponent },


### PR DESCRIPTION
Agora 3.0 introduced new URLs for certain parts of the app.

This PR adds redirect routes and a CustomUrlHandler to enable continued support for specific 2.x legacy URLs that no longer work after the 3.0 rewrite:

* /(genes-router:gene-details/ENSG00000147065)
* /genes/(genes-router:genes-list)