### PR TITLE
Update linux distro (#1143)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: focal
+dist: jammy
 language: node_js
 addons:
   chrome: stable


### PR DESCRIPTION
The travis CI build is now failing with error..
```
AttributeError: module 'lib' has no attribute 'X509_V_FLAG_CB_ISSUER_CHECK'
```

which seems like an OpenSSL issue in ubuntu linux[1]. Attempt to fix by updating the distro.

[1] https://askubuntu.com/questions/1428181/module-lib-has-no-attribute-x509-v-flag-cb-issuer-check