### PR TITLE
AG-972 - updating chips

### DIFF
--- a/src/app/features/genes/components/gene-comparison-tool/components/gene-comparison-tool-filter-list/gene-comparison-tool-filter-list.component.html
+++ b/src/app/features/genes/components/gene-comparison-tool/components/gene-comparison-tool-filter-list/gene-comparison-tool-filter-list.component.html
@@ -10,13 +10,6 @@
       <ng-container *ngFor="let filter of filters; index as i">
         <ng-container *ngFor="let option of filter.options; index as j">
           <div *ngIf="option.selected" class="gct-filter-list-item">
-            <div>
-              <button class="gct-filter-list-item-handle">
-                <span></span>
-                <span></span>
-                <span></span>
-              </button>
-            </div>
             <div class="gct-filter-list-item-text">
               <b>{{ filter.short }}:</b>&nbsp;<span>{{ option.label }}</span>
             </div>

--- a/src/app/features/genes/components/gene-comparison-tool/components/gene-comparison-tool-filter-list/gene-comparison-tool-filter-list.component.html
+++ b/src/app/features/genes/components/gene-comparison-tool/components/gene-comparison-tool-filter-list/gene-comparison-tool-filter-list.component.html
@@ -11,7 +11,7 @@
         <ng-container *ngFor="let option of filter.options; index as j">
           <div *ngIf="option.selected" class="gct-filter-list-item">
             <div class="gct-filter-list-item-text">
-              <b>{{ filter.short }}:</b>&nbsp;<span>{{ option.label }}</span>
+              <b>{{ filter.short }}:</b><span>&nbsp;{{ option.label }}</span>
             </div>
             <div>
               <button

--- a/src/app/features/genes/components/gene-comparison-tool/components/gene-comparison-tool-filter-list/gene-comparison-tool-filter-list.component.scss
+++ b/src/app/features/genes/components/gene-comparison-tool/components/gene-comparison-tool-filter-list/gene-comparison-tool-filter-list.component.scss
@@ -58,21 +58,6 @@
     align-items: center;
   }
 
-  .gct-filter-list-item-handle {
-    margin-right: 12px;
-
-    span {
-      display: block;
-      width: 10px;
-      height: 2px;
-      background-color: var(--color-action-primary);
-
-      &:not(:last-child) {
-        margin-bottom: 2px;
-      }
-    }
-  }
-
   .gct-filter-list-item-clear {
     cursor: pointer;
     margin-left: 12px;

--- a/src/app/features/genes/components/gene-comparison-tool/components/gene-comparison-tool-filter-list/gene-comparison-tool-filter-list.component.scss
+++ b/src/app/features/genes/components/gene-comparison-tool/components/gene-comparison-tool-filter-list/gene-comparison-tool-filter-list.component.scss
@@ -58,6 +58,10 @@
     align-items: center;
   }
 
+  .gct-filter-list-item-text > *:hover {
+    cursor: default;
+  }
+
   .gct-filter-list-item-clear {
     cursor: pointer;
     margin-left: 12px;


### PR DESCRIPTION
In the GCT (Gene comparison tool), the filter chips have a menu hamburger icon preceding the text (this is confusing since it isn't a menu or used to move things).  So this ticket is to remove this visual element.  The css styled spans that were being used were removed and the css deleted.

Although not mentioned in the ticket, the text is selectable so css was used to disable the selectability of the text: e.g. "Nominations: #"