### PR TITLE
AG-975: Update GenomicsDB resource link

### DIFF
--- a/src/app/features/genes/components/gene-resources/gene-resources.component.ts
+++ b/src/app/features/genes/components/gene-resources/gene-resources.component.ts
@@ -63,7 +63,7 @@ export class GeneResourcesComponent {
         description:
           'View this gene on the National Institute on Aging Genetics of Alzheimer\'s Disease Data Storage Site (NIAGADS) Genomics Database.',
         linkText: 'Visit Genomics DB',
-        link: `https://www.niagads.org/genomics/showRecord.do?name=GeneRecordClasses.GeneRecordClass&source_id=${this.gene?.ensembl_gene_id}`,
+        link: `https://www.niagads.org/genomics/app/record/gene/${this.gene?.ensembl_gene_id}`,
       },
       {
         title: 'AD Atlas',


### PR DESCRIPTION
The GenomicsDB URL was changed, so we need to update the related links on the Resources tab to un-break them.