### PR TITLE
[IT-2407] Configure http to https redirect

### DIFF
--- a/.ebextensions/alb-http-to-https-redirection.config
+++ b/.ebextensions/alb-http-to-https-redirection.config
@@ -1,0 +1,40 @@
+###################################################################################################
+#### Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+####
+#### Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file
+#### except in compliance with the License. A copy of the License is located at
+####
+####     http://aws.amazon.com/apache2.0/
+####
+#### or in the "license" file accompanying this file. This file is distributed on an "AS IS"
+#### BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#### License for the specific language governing permissions and limitations under the License.
+###################################################################################################
+
+###################################################################################################
+#### This configuration file modifies the default port 80 listener attached to an Application Load Balancer
+#### to automatically redirect incoming connections on HTTP to HTTPS.
+#### This will not work with an environment using the load balancer type Classic or Network.
+#### A prerequisite is that the 443 listener has already been created.
+#### Please use the below link for more information about creating an Application Load Balancer on
+#### the Elastic Beanstalk console.
+#### https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/environments-cfg-alb.html#environments-cfg-alb-console
+###################################################################################################
+
+Resources:
+  AWSEBV2LoadBalancerListener:
+    Type: AWS::ElasticLoadBalancingV2::Listener
+    Properties:
+      LoadBalancerArn:
+        Ref: AWSEBV2LoadBalancer
+      Port: 80
+      Protocol: HTTP
+      DefaultActions:
+        - Type: redirect
+          RedirectConfig:
+            Host: "#{host}"
+            Path: "/#{path}"
+            Port: "443"
+            Protocol: "HTTPS"
+            Query: "#{query}"
+            StatusCode: "HTTP_301"


### PR DESCRIPTION
Redirect http requests to https for secure connections[1]

[1] https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/configuring-https-httpredirect.html