### PR TITLE
AG-1128 making hyperlink styling consistent for details page

### DIFF
--- a/src/app/features/genes/components/gene-soe-list/gene-soe-list.component.scss
+++ b/src/app/features/genes/components/gene-soe-list/gene-soe-list.component.scss
@@ -28,6 +28,11 @@
     .item-title,
     .item-description {
       max-width: 600px;
+
+      a {
+        color: var(--color-link);
+        font-size: 16px;
+      }
     }
 
     .item-title {

--- a/src/app/features/genes/components/gene-soe/gene-soe.component.scss
+++ b/src/app/features/genes/components/gene-soe/gene-soe.component.scss
@@ -8,5 +8,5 @@
 
 a {
     color: var(--color-link);
-    font-size: 18px;
+    font-size: 16px;
 }


### PR DESCRIPTION
Updating hyperlink styling as per Ljubo's feedback.  Previously, font size was too large.  All hyperlinks should be the same size as the surrounding text.