### PR TITLE
AG-1115: prevent CI values from overlapping in GCT circle overlay by re-positioning labels

### DIFF
--- a/src/app/features/genes/components/gene-comparison-tool/components/gene-comparison-tool-details-panel/gene-comparison-tool-details-panel.component.html
+++ b/src/app/features/genes/components/gene-comparison-tool/components/gene-comparison-tool-details-panel/gene-comparison-tool-details-panel.component.html
@@ -36,10 +36,10 @@
             [style]="getIntervalPositions(data)"
           >
             <div>
-              <div>{{ getSignificantFigures(data.intervalMin, 3) }}</div>
+              <div class="gct-details-panel-chart-interval-left">{{ getSignificantFigures(data.intervalMin, 3) }}</div>
             </div>
             <div>
-              <div>{{ getSignificantFigures(data.intervalMax, 3) }}</div>
+              <div class="gct-details-panel-chart-interval-right">{{ getSignificantFigures(data.intervalMax, 3) }}</div>
             </div>
           </div>
           <div

--- a/src/app/features/genes/components/gene-comparison-tool/components/gene-comparison-tool-details-panel/gene-comparison-tool-details-panel.component.scss
+++ b/src/app/features/genes/components/gene-comparison-tool/components/gene-comparison-tool-details-panel/gene-comparison-tool-details-panel.component.scss
@@ -134,7 +134,14 @@
           font-size: var(--font-size-sm);
           top: 100%;
           left: 50%;
-          transform: translate(-50%, 14px);
+          
+          &.gct-details-panel-chart-interval-left {
+            transform: translate(-95%, 14px);
+          }
+
+          &.gct-details-panel-chart-interval-right {
+            transform: translate(-5%, 14px);
+          }
         }
 
         &:first-child {


### PR DESCRIPTION
gene tissue | develop | feature
:---:|:---:|:---:
ABCA8 PHG | <img width="626" alt="develop_ABCA8_PHG" src="https://github.com/Sage-Bionetworks/Agora/assets/26949006/45cb43f2-fdd3-4386-a1d3-9b0d154ffefc"> | <img width="625" alt="feature_ABCA8_PHG_moveLabels" src="https://github.com/Sage-Bionetworks/Agora/assets/26949006/11840dbb-175b-400a-a1f6-e43900409cb2">
APP CBE | <img width="641" alt="develop_APP_CBE" src="https://github.com/Sage-Bionetworks/Agora/assets/26949006/4bae5094-79d5-4a60-875a-ead76720b8f9"> | <img width="624" alt="feature_APP_CBE_moveLabels" src="https://github.com/Sage-Bionetworks/Agora/assets/26949006/3a90f7fc-77db-472c-8b75-a5de34cdc271">
APP DLPFC | <img width="637" alt="develop_APP_DLPFC" src="https://github.com/Sage-Bionetworks/Agora/assets/26949006/3776efaf-3cec-4889-9000-56743837f375"> | <img width="627" alt="feature_APP_DLPFC_moveLabels" src="https://github.com/Sage-Bionetworks/Agora/assets/26949006/a1ef266d-7fa2-41f9-8f36-f133850a9c3e">
