### PR TITLE
AG-1115: prevent CI values from overlapping in GCT circle overlay by adjusting displayed limits

### DIFF
--- a/src/app/features/genes/components/gene-comparison-tool/components/gene-comparison-tool-details-panel/gene-comparison-tool-details-panel.component.html
+++ b/src/app/features/genes/components/gene-comparison-tool/components/gene-comparison-tool-details-panel/gene-comparison-tool-details-panel.component.html
@@ -27,7 +27,7 @@
 
     <div class="gct-details-panel-chart">
       <div>
-        <div>{{ data.min }}</div>
+        <div>{{ getSignificantFigures(data.min, 2) }}</div>
       </div>
       <div>
         <div class="gct-details-panel-chart-axis">
@@ -51,7 +51,7 @@
         </div>
       </div>
       <div>
-        <div>{{ data.max }}</div>
+        <div>{{ getSignificantFigures(data.max, 2) }}</div>
       </div>
     </div>
 

--- a/src/app/features/genes/components/gene-comparison-tool/gene-comparison-tool.helpers.ts
+++ b/src/app/features/genes/components/gene-comparison-tool/gene-comparison-tool.helpers.ts
@@ -114,7 +114,7 @@ export const getDetailsPanelData = function (
     }
   });
 
-  max = Math.ceil(max);
+  max = max * 1.1;
 
   const data = {
     gene: gene,


### PR DESCRIPTION
gene tissue | develop | feature
:---:|:---:|:---:
ABCA8 PHG | <img width="626" alt="develop_ABCA8_PHG" src="https://github.com/Sage-Bionetworks/Agora/assets/26949006/6af2aa57-3151-4266-9beb-1f00b69c6309"> | <img width="625" alt="feature_ABCA8_PHG_adjustLimits" src="https://github.com/Sage-Bionetworks/Agora/assets/26949006/45f1bb06-bf0e-45fe-908d-7189ac87d111">
APP CBE | <img width="641" alt="develop_APP_CBE" src="https://github.com/Sage-Bionetworks/Agora/assets/26949006/6a4c7c50-3aa8-4dbe-a3b6-a9807d5a3f5d"> | <img width="621" alt="feature_APP_CBE_adjustLimits" src="https://github.com/Sage-Bionetworks/Agora/assets/26949006/79d0cbd9-8228-4a6e-8be1-7082fef7993f">
APP DLPFC | <img width="637" alt="develop_APP_DLPFC" src="https://github.com/Sage-Bionetworks/Agora/assets/26949006/f1547f0c-7c1e-45a1-8831-87bc2cb52ee3"> | <img width="623" alt="feature_APP_DLPFC_adjustLimits" src="https://github.com/Sage-Bionetworks/Agora/assets/26949006/6d3ffb98-ee1e-4175-af4e-638e894a370a">
