### PR TITLE
AG-982: Include gene scores and linked biodomains in csv download

### DIFF
--- a/src/app/core/services/api.service.spec.ts
+++ b/src/app/core/services/api.service.spec.ts
@@ -12,6 +12,8 @@ import {
 // -------------------------------------------------------------------------- //
 import { ApiService } from './';
 import {
+  bioDomainInfoMock,
+  bioDomainsMock,
   geneMock1,
   geneMock2,
   gctGeneMock1,
@@ -44,6 +46,30 @@ describe('Service: API', () => {
 
   it('should create', () => {
     expect(apiService).toBeDefined();
+  });
+
+  it('should get data from /api/biodomains/', () => {
+    const mockResponse = bioDomainInfoMock;
+
+    apiService.getBiodomains().subscribe((response) => {
+      expect(response).toEqual(mockResponse);
+    });
+
+    const req = httpMock.expectOne('/api/biodomains');
+    expect(req.request.method).toBe('GET');
+    req.flush(mockResponse);
+  });
+
+  it('should get data from /api/biodomains/:id', () => {
+    const mockResponse = bioDomainsMock.gene_biodomains;
+
+    apiService.getBiodomain(bioDomainsMock.ensembl_gene_id).subscribe((response) => {
+      expect(response).toEqual(mockResponse);
+    });
+
+    const req = httpMock.expectOne('/api/biodomains/' + bioDomainsMock.ensembl_gene_id);
+    expect(req.request.method).toBe('GET');
+    req.flush(mockResponse);
   });
 
   it('should get data from /api/genes/:id', () => {

--- a/src/app/features/genes/services/gene.service.spec.ts
+++ b/src/app/features/genes/services/gene.service.spec.ts
@@ -12,7 +12,7 @@ import {
 // -------------------------------------------------------------------------- //
 import { GeneService } from '.';
 import { ApiService } from '../../../core/services';
-import { geneMock1, gctGeneMock1, distributionMock } from '../../../testing';
+import { geneMock1, gctGeneMock1, distributionMock, bioDomainsMock, bioDomainInfoMock } from '../../../testing';
 
 // -------------------------------------------------------------------------- //
 // Tests
@@ -88,6 +88,30 @@ describe('Service: Gene', () => {
     const req = httpMock.expectOne(
       '/api/genes/comparison?category=RNA%20-%20Differential%20Expression&subCategory=AD%20Diagnosis%20(males%20and%20females)'
     );
+    expect(req.request.method).toBe('GET');
+    req.flush(mockResponse);
+  });
+
+  it('should get biodomains', () => {
+    const mockResponse = bioDomainsMock.gene_biodomains;
+
+    geneService.getBiodomains(bioDomainsMock.ensembl_gene_id).subscribe((response) => {
+      expect(response).toEqual(mockResponse);
+    });
+
+    const req = httpMock.expectOne('/api/biodomains/' + bioDomainsMock.ensembl_gene_id);
+    expect(req.request.method).toBe('GET');
+    req.flush(mockResponse);
+  });
+
+  it('should get all biodomains', () => {
+    const mockResponse = bioDomainInfoMock;
+
+    geneService.getAllBiodomains().subscribe((response) => {
+      expect(response).toEqual(mockResponse);
+    });
+
+    const req = httpMock.expectOne('/api/biodomains');
     expect(req.request.method).toBe('GET');
     req.flush(mockResponse);
   });

--- a/src/app/testing/biodomain-mocks.ts
+++ b/src/app/testing/biodomain-mocks.ts
@@ -1,0 +1,47 @@
+/* eslint-disable */
+
+import { BioDomainInfo, BioDomain, BioDomains } from '../models';
+
+export const bioDomainInfoMock: BioDomainInfo[] = [
+  {
+    name: 'Cell Cycle'
+  },
+  {
+    name: 'Lipid Metabolism'
+  },
+  {
+    name: 'Structural Stabilization'
+  }, 
+];
+
+export const bioDomainMock1: BioDomain = {
+  biodomain: 'Cell Cycle',
+  go_terms: ['G1/S transition of mitotic cell cycle'],
+  n_biodomain_terms: 211,
+  n_gene_biodomain_terms: 1,
+  pct_linking_terms: 25,
+};
+
+export const bioDomainMock2: BioDomain = {
+  biodomain: 'Lipid Metabolism',
+  go_terms: ['lateral plasma membrane'],
+  n_biodomain_terms: 827,
+  n_gene_biodomain_terms: 1,
+  pct_linking_terms: 25,
+};
+
+export const bioDomainMock3: BioDomain = {
+  biodomain: 'Structural Stabilization',
+  go_terms: [
+    'cell-cell junction',
+    'regulation of actin cytoskeleton organization',
+  ],
+  n_biodomain_terms: 466,
+  n_gene_biodomain_terms: 2,
+  pct_linking_terms: 50,
+};
+
+export const bioDomainsMock: BioDomains = {
+  ensembl_gene_id: 'ENSG00000183856',
+  gene_biodomains: [bioDomainMock1, bioDomainMock2, bioDomainMock3],
+};

--- a/src/app/testing/index.ts
+++ b/src/app/testing/index.ts
@@ -1,4 +1,5 @@
 // Mocks
+export * from './biodomain-mocks';
 export * from './distribution-mocks';
 export * from './gene-mocks';
 export * from './gene-network-mocks';

--- a/src/server/components/biodomains.ts
+++ b/src/server/components/biodomains.ts
@@ -72,7 +72,7 @@ export async function allBiodomainsRoute(
   try {
     const result = await getAllBioDomains();
     setHeaders(res);
-    res.json({ items: result });
+    res.json(result);
   } catch (err) {
     next(err);
   }
@@ -91,7 +91,7 @@ export async function biodomainsRoute(
   try {
     const result = await getBioDomains(<string>req.params.id);
     setHeaders(res);
-    res.json({ items: result });
+    res.json(result?.gene_biodomains);
   } catch (err) {
     next(err);
   }


### PR DESCRIPTION
- AG-982: Include gene scores and linked biodomains in csv download
- Add tests and mocks for biodomains routes