### PR TITLE
AG-1170: fix url parameter for p-value filter

### DIFF
--- a/src/app/features/genes/components/gene-comparison-tool/gene-comparison-tool.component.spec.ts
+++ b/src/app/features/genes/components/gene-comparison-tool/gene-comparison-tool.component.spec.ts
@@ -32,7 +32,7 @@ class ActivatedRouteStub {
   queryParams = new Observable((observer) => {
     const urlParams = {
       pinned: ['ENSG00000147065'],
-      significanceThreshold: DEFAULT_SIGNIFICANCE_THRESHOLD,
+      significance: DEFAULT_SIGNIFICANCE_THRESHOLD,
     };
     observer.next(urlParams);
     observer.complete();
@@ -376,7 +376,7 @@ describe('Component: GeneComparisonToolComponent', () => {
       expect(
         element.querySelector(TOGGLE_CLASS)?.querySelector('input')?.checked
       ).toBeTrue();
-      expect(component.getUrlParam('significanceThreshold')[0]).toEqual(
+      expect(component.getUrlParam('significance')[0]).toEqual(
         threshold
       );
     };
@@ -386,7 +386,7 @@ describe('Component: GeneComparisonToolComponent', () => {
       expect(
         element.querySelector(TOGGLE_CLASS)?.querySelector('input')?.checked
       ).toBeFalse();
-      expect(component.getUrlParam('significanceThreshold')).toEqual(null);
+      expect(component.getUrlParam('significance')).toEqual(null);
     };
 
     // tests

--- a/src/app/features/genes/components/gene-comparison-tool/gene-comparison-tool.component.ts
+++ b/src/app/features/genes/components/gene-comparison-tool/gene-comparison-tool.component.ts
@@ -138,9 +138,9 @@ export class GeneComparisonToolComponent implements OnInit, AVI, OnDestroy {
       this.sortOrder = '1' === this.urlParams.sortOrder ? 1 : -1;
 
       this.significanceThreshold =
-        this.urlParams.significanceThreshold ||
+        this.urlParams.significance ||
         this.DEFAULT_SIGNIFICANCE_THRESHOLD;
-      this.significanceThresholdActive = !!this.urlParams.significanceThreshold;
+      this.significanceThresholdActive = !!this.urlParams.significance;
 
       this.loadGenes();
     });
@@ -768,7 +768,7 @@ export class GeneComparisonToolComponent implements OnInit, AVI, OnDestroy {
     }
 
     if (this.significanceThresholdActive) {
-      params['significanceThreshold'] = [this.significanceThreshold];
+      params['significance'] = [this.significanceThreshold];
     }
 
     this.urlParams = params;


### PR DESCRIPTION
- Use "significance" instead of "significanceThreshold" for the p-value filter url parameter