### PR TITLE
AG-1166: title of go terms section doesn't display biodomain when there are no go terms

### DIFF
--- a/src/app/features/genes/components/gene-biodomains/gene-biodomains.component.spec.ts
+++ b/src/app/features/genes/components/gene-biodomains/gene-biodomains.component.spec.ts
@@ -9,7 +9,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 // -------------------------------------------------------------------------- //
 import { GeneBioDomainsComponent } from './';
 import { HelperService } from '../../../../core/services';
-import { geneMock1 } from '../../../../testing';
+import { emptyBioDomainMock, geneMock1 } from '../../../../testing';
 
 // -------------------------------------------------------------------------- //
 // Tests
@@ -49,8 +49,9 @@ describe('Component: Gene Biodomains', () => {
   });
 
   it('should return NO LINKING GO TERMS when getHeaderText() is called with no go terms', () => {
+    component.selectedBioDomain = emptyBioDomainMock;
     component.goTerms = [];
     const result = component.getHeaderText();
-    expect(result).toBe('NO LINKING GO TERMS');
+    expect(result).toBe(`NO LINKING GO TERMS FOR ${emptyBioDomainMock.biodomain.toUpperCase()}`);
   });
 });

--- a/src/app/features/genes/components/gene-biodomains/gene-biodomains.component.ts
+++ b/src/app/features/genes/components/gene-biodomains/gene-biodomains.component.ts
@@ -97,9 +97,10 @@ export class GeneBioDomainsComponent implements OnInit {
   }
 
   getHeaderText() {
+    const baseText = `LINKING GO TERMS FOR ${ this.selectedBioDomain?.biodomain.toUpperCase() }`;
     if (this.goTerms.length === 0)
-      return 'NO LINKING GO TERMS';
-    return `LINKING GO TERMS FOR ${ this.selectedBioDomain?.biodomain.toUpperCase() } (${ this.selectedBioDomain?.n_gene_biodomain_terms}/${ this.selectedBioDomain?.n_biodomain_terms})`;
+      return `NO ${baseText}`;
+    return `${baseText} (${ this.selectedBioDomain?.n_gene_biodomain_terms}/${ this.selectedBioDomain?.n_biodomain_terms})`;
   }
 
   capitalizeGoTerm(goTerm: string) {

--- a/src/app/testing/biodomain-mocks.ts
+++ b/src/app/testing/biodomain-mocks.ts
@@ -14,6 +14,14 @@ export const bioDomainInfoMock: BioDomainInfo[] = [
   }, 
 ];
 
+export const emptyBioDomainMock: BioDomain = {
+  biodomain: "Autophagy",
+  go_terms: [],
+  n_biodomain_terms: 0,
+  n_gene_biodomain_terms: 0,
+  pct_linking_terms: 0
+};
+
 export const bioDomainMock1: BioDomain = {
   biodomain: 'Cell Cycle',
   go_terms: ['G1/S transition of mitotic cell cycle'],


### PR DESCRIPTION

https://github.com/Sage-Bionetworks/Agora/assets/26949006/ec2b3cbc-849a-4d5d-9a0b-cf78e0501273

