### PR TITLE
AG-1113: use preventDefault to prevent score labels from moving when double clicking on histogram in GCT overlay

### DIFF
--- a/src/app/features/charts/components/score-barchart/score-barchart.component.ts
+++ b/src/app/features/charts/components/score-barchart/score-barchart.component.ts
@@ -254,6 +254,15 @@ export class ScoreBarChartComponent implements OnChanges, AfterViewInit, OnDestr
             return this.helperService.roundNumber(this.score as number, 2);
           return '';
         })
+        // AG-1113: prevent label text from moving in PrimeNG OverlayPanel
+        // see: https://sagebionetworks.jira.com/browse/AG-1113
+        .on('mousedown', (event) => {
+          event.preventDefault();
+        })
+        .on('contextmenu', (event) => {
+          event.preventDefault();
+        })
+        // end changes related to AG-1113 
         .on('mouseenter', (_, d) => {
           const index = this.scoreIndex;
           const tooltipText = this.getToolTipText(d.bins[0] as number, d.bins[1] as number, d.distribution);


### PR DESCRIPTION
Downside of this approach -- the context menu no longer appears when right clicking on the label

https://github.com/Sage-Bionetworks/Agora/assets/26949006/199169bb-2960-4e51-8fe9-78c5b1027f6d

