### PR TITLE
AG-1113: use user-select to prevent score labels from moving when double clicking on histogram in GCT overlay

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5779,9 +5779,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001380",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001380.tgz",
-      "integrity": "sha512-OO+pPubxx16lkI7TVrbFpde8XHz66SMwstl1YWpg6uMGw56XnhYVwtPIjvX4kYpzwMwQKr4DDce394E03dQPGg==",
+      "version": "1.0.30001512",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001512.tgz",
+      "integrity": "sha512-2S9nK0G/mE+jasCUsMPlARhRCts1ebcp2Ji8Y8PWi4NDE1iRdLCnEPHkEfeBrGC45L4isBx5ur3IQ6yTE2mRZw==",
       "dev": true,
       "funding": [
         {
@@ -5791,6 +5791,10 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ]
     },
@@ -25340,9 +25344,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001380",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001380.tgz",
-      "integrity": "sha512-OO+pPubxx16lkI7TVrbFpde8XHz66SMwstl1YWpg6uMGw56XnhYVwtPIjvX4kYpzwMwQKr4DDce394E03dQPGg==",
+      "version": "1.0.30001512",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001512.tgz",
+      "integrity": "sha512-2S9nK0G/mE+jasCUsMPlARhRCts1ebcp2Ji8Y8PWi4NDE1iRdLCnEPHkEfeBrGC45L4isBx5ur3IQ6yTE2mRZw==",
       "dev": true
     },
     "caseless": {

--- a/src/app/features/charts/components/score-barchart/score-barchart.component.scss
+++ b/src/app/features/charts/components/score-barchart/score-barchart.component.scss
@@ -60,6 +60,10 @@ $tooltip-color: #63676C;
     .bar-labels {
         &:hover {
             cursor: pointer;
+
+            // AG-1113: prevent label text from moving in PrimeNG OverlayPanel
+            // see: https://sagebionetworks.jira.com/browse/AG-1113
+            user-select: none; 
         }
     }
 


### PR DESCRIPTION
Pro: context menu still appears when right clicking the label
Requires: updating caniuse-lite so stylelint plugin/no-unsupported-browser-features recognizes that "user-select-none" is supported by UC Browser for Android

https://github.com/Sage-Bionetworks/Agora/assets/26949006/48d287b3-6f82-4f38-9dca-317d633ebd1c

