### PR TITLE
AG-1193: Bump data manifest to v57 to pick up TER fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agora",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "data-file": "syn13363290",
   "data-version": "57",
   "private": true,

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "agora",
   "version": "3.2.0",
   "data-file": "syn13363290",
-  "data-version": "56",
+  "data-version": "57",
   "private": true,
   "scripts": {
     "dev": "concurrently --kill-others \"npm:dev:server\" \"npm:dev:app\"",


### PR DESCRIPTION
@sagely1 This PR updates the application and data manifest version displayed in the app. Merging this PR to dev will force agora-develop to restart, ensuring that any cached data is replaced with the new data in the dev db. 