### PR TITLE
AG-1305: Bump data-version to ALD mv66

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "agora",
   "version": "3.3.0",
   "data-file": "syn13363290",
-  "data-version": "64",
+  "data-version": "65",
   "private": true,
   "scripts": {
     "dev": "concurrently --kill-others \"npm:dev:server\" \"npm:dev:app\"",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "agora",
   "version": "3.3.0",
   "data-file": "syn13363290",
-  "data-version": "65",
+  "data-version": "66",
   "private": true,
   "scripts": {
     "dev": "concurrently --kill-others \"npm:dev:server\" \"npm:dev:app\"",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "agora",
   "version": "3.3.0",
   "data-file": "syn13363290",
-  "data-version": "61",
+  "data-version": "64",
   "private": true,
   "scripts": {
     "dev": "concurrently --kill-others \"npm:dev:server\" \"npm:dev:app\"",


### PR DESCRIPTION
This PR just bumps the footer version to display the actual data version currently deployed in dev, and can be merged at your convenience.