### PR TITLE
AG-1281 fixing obscured tooltip

### DIFF
--- a/src/styles/components/_dropdown.scss
+++ b/src/styles/components/_dropdown.scss
@@ -32,6 +32,7 @@ div.p-dropdown {
 }
 
 .p-multiselect {
+  z-index: 1000 !important; 
   width: 100%;
   color: #fff;
   position: relative;

--- a/src/styles/components/_table.scss
+++ b/src/styles/components/_table.scss
@@ -116,6 +116,7 @@
 }
 
 .tooltip.gene-table-tooltip {
+  z-index: 999 !important;
   top: -30px !important;
   left: 50% !important;
 


### PR DESCRIPTION
Fixing prime dropdown list items obscured when user opens prime dropdown and then hovers over a tooltip-enabled element.