### PR TITLE
AG-1599 - handle a list of pharos class values

### DIFF
--- a/src/app/features/genes/components/gene-druggability/gene-druggability.component.ts
+++ b/src/app/features/genes/components/gene-druggability/gene-druggability.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, Input } from '@angular/core';
+import { Component, Input } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 
 import { Gene, Druggability } from '../../../../models';
@@ -18,7 +18,7 @@ export interface GeneResourceType {
   templateUrl: './gene-druggability.component.html',
   styleUrls: ['./gene-druggability.component.scss'],
 })
-export class GeneDruggabilityComponent implements OnInit {
+export class GeneDruggabilityComponent {
   _gene: Gene | undefined;
   get gene(): Gene | undefined {
     return this._gene;
@@ -43,28 +43,23 @@ export class GeneDruggabilityComponent implements OnInit {
     private geneService: GeneService
   ) {}
 
-  ngOnInit() {
-    //
-  }
-
   init() {
     // Update the initial buckets
     if (this.gene) {
       if (!this.gene.druggability) {
-        this.gene.druggability = [
-          {
-            sm_druggability_bucket: this.getDefaultBucketNumber(),
-            safety_bucket: this.getDefaultBucketNumber(),
-            abability_bucket: this.getDefaultBucketNumber(),
-            pharos_class: '',
-            classification: this.getDefaultText(),
-            safety_bucket_definition: this.getDefaultText(),
-            abability_bucket_definition: this.getDefaultText(),
-          },
-        ];
+        this.gene.druggability =
+        {
+          sm_druggability_bucket: this.getDefaultBucketNumber(),
+          safety_bucket: this.getDefaultBucketNumber(),
+          abability_bucket: this.getDefaultBucketNumber(),
+          pharos_class: [],
+          classification: this.getDefaultText(),
+          safety_bucket_definition: this.getDefaultText(),
+          abability_bucket_definition: this.getDefaultText(),
+        };
       }
 
-      this.druggability = this.gene.druggability[0];
+      this.druggability = this.gene.druggability;
       this.currentBucketSM = this.druggability.sm_druggability_bucket;
       this.currentBucketAB = this.druggability.abability_bucket;
       this.currentBucketSF = this.druggability.safety_bucket;

--- a/src/app/features/genes/components/gene-hero/gene-hero.component.html
+++ b/src/app/features/genes/components/gene-hero/gene-hero.component.html
@@ -22,9 +22,9 @@
             {{ getBiodomains() }}
           </p>
         </div>
-        <div *ngIf="gene.druggability[0].pharos_class" class="gene-hero-pharos">
+        <div *ngIf="gene.druggability && gene.druggability.pharos_class" class="gene-hero-pharos">
           <h4 class="gene-hero-pharos-heading">Pharos Class</h4>
-          <p>{{ gene.druggability[0].pharos_class }}</p>
+          <p>{{ gene.druggability.pharos_class.join(', ') }}</p>
         </div>
         <div class="gene-hero-aliases">
           <h4 class="gene-hero-aliases-heading">Also known as</h4>

--- a/src/app/features/genes/components/gene-nominated-targets/gene-nominated-targets.component.ts
+++ b/src/app/features/genes/components/gene-nominated-targets/gene-nominated-targets.component.ts
@@ -119,13 +119,7 @@ export class GeneNominatedTargetsComponent implements OnInit {
           : undefined;
 
         // Populate Druggability display fields
-        if (de.druggability && de.druggability.length) {
-          de.pharos_class_display_value = de.druggability[0].pharos_class
-            ? de.druggability[0].pharos_class
-            : 'No value';
-        } else {
-          de.pharos_class_display_value = 'No value';
-        }
+        de.pharos_class_display_value = de.druggability.pharos_class;
       });
 
       this.genes = genes;

--- a/src/app/features/genes/components/gene-similar/gene-similar.component.ts
+++ b/src/app/features/genes/components/gene-similar/gene-similar.component.ts
@@ -107,13 +107,7 @@ export class GeneSimilarComponent implements OnInit {
           de.nominated_target_display_value = false;
 
         // Populate Druggability display fields
-        if (de.druggability && de.druggability.length) {
-          de.pharos_class_display_value = de.druggability[0].pharos_class
-            ? de.druggability[0].pharos_class
-            : 'No value';
-        } else {
-          de.pharos_class_display_value = 'No value';
-        }
+        de.pharos_class_display_value = de.druggability.pharos_class;
       });
 
       this.genes = genes;

--- a/src/app/models/genes.ts
+++ b/src/app/models/genes.ts
@@ -23,7 +23,6 @@ export interface TargetNomination {
   input_data: string;
   validation_study_details: string;
   initial_nomination: number;
-  //
   team_data?: Team;
 }
 
@@ -41,7 +40,7 @@ export interface Druggability {
   sm_druggability_bucket: number;
   safety_bucket: number;
   abability_bucket: number;
-  pharos_class: string;
+  pharos_class: string[];
   // classification should really be named sm_druggability_bucket_definition
   classification: string;
   safety_bucket_definition: string;
@@ -64,7 +63,7 @@ export interface Gene {
   protein_brain_change_studied: boolean;
   target_nominations: TargetNomination[] | null;
   median_expression: MedianExpression[];
-  druggability: Druggability[];
+  druggability: Druggability;
   total_nominations: number | null;
   is_adi: boolean;
   is_tep: boolean;
@@ -85,7 +84,7 @@ export interface Gene {
   similar_genes_network?: SimilarGenesNetwork;
 
   // Similar table (not in mongo document)
-  pharos_class_display_value?: string;
+  pharos_class_display_value?: string[];
   is_any_rna_changed_in_ad_brain_display_value?: string;
   is_any_protein_changed_in_ad_brain_display_value?: string;
   nominated_target_display_value?: boolean;

--- a/src/app/testing/gene-mocks.ts
+++ b/src/app/testing/gene-mocks.ts
@@ -205,20 +205,18 @@ export const geneMock1: Gene = {
       tissue: 'STG',
     },
   ],
-  druggability: [
-    {
-      sm_druggability_bucket: 3,
-      safety_bucket: 4,
-      abability_bucket: 3,
-      pharos_class: 'Tbio',
-      classification:
-        'Targetable by structure: Structurally druggable protein, based on the presence of a druggable pocket in the protein (DrugEBIlity/CanSAR).',
-      safety_bucket_definition:
-        'More than two of: high off target gene expression, cancer driver, essential gene, associated deleterious genetic disorder, HPO phenotype associated gene, or black box warning on clinically used drug.',
-      abability_bucket_definition:
-        'Cell membrane-bound proteins. Highly accessible to antibody-based therapies, but potentially less so than secreted proteins or ECM components.',
-    },
-  ],
+  druggability: {
+    sm_druggability_bucket: 3,
+    safety_bucket: 4,
+    abability_bucket: 3,
+    pharos_class: ['Tbio'],
+    classification:
+      'Targetable by structure: Structurally druggable protein, based on the presence of a druggable pocket in the protein (DrugEBIlity/CanSAR).',
+    safety_bucket_definition:
+      'More than two of: high off target gene expression, cancer driver, essential gene, associated deleterious genetic disorder, HPO phenotype associated gene, or black box warning on clinically used drug.',
+    abability_bucket_definition:
+      'Cell membrane-bound proteins. Highly accessible to antibody-based therapies, but potentially less so than secreted proteins or ECM components.',
+  },
   total_nominations: 5,
   rna_differential_expression: [
     {
@@ -3129,20 +3127,18 @@ export const geneMock2: Gene = {
       tissue: 'STG',
     },
   ],
-  druggability: [
-    {
-      sm_druggability_bucket: 3,
-      safety_bucket: 4,
-      abability_bucket: 3,
-      pharos_class: 'Tbio',
-      classification:
-        'Targetable by structure: Structurally druggable protein, based on the presence of a druggable pocket in the protein (DrugEBIlity/CanSAR).',
-      safety_bucket_definition:
-        'More than two of: high off target gene expression, cancer driver, essential gene, associated deleterious genetic disorder, HPO phenotype associated gene, or black box warning on clinically used drug.',
-      abability_bucket_definition:
-        'Cell membrane-bound proteins. Highly accessible to antibody-based therapies, but potentially less so than secreted proteins or ECM components.',
-    },
-  ],
+  druggability: {
+    sm_druggability_bucket: 3,
+    safety_bucket: 4,
+    abability_bucket: 3,
+    pharos_class: ['Tbio'],
+    classification:
+      'Targetable by structure: Structurally druggable protein, based on the presence of a druggable pocket in the protein (DrugEBIlity/CanSAR).',
+    safety_bucket_definition:
+      'More than two of: high off target gene expression, cancer driver, essential gene, associated deleterious genetic disorder, HPO phenotype associated gene, or black box warning on clinically used drug.',
+    abability_bucket_definition:
+      'Cell membrane-bound proteins. Highly accessible to antibody-based therapies, but potentially less so than secreted proteins or ECM components.',
+  },
   total_nominations: 3,
   is_adi: false,
   is_tep: true,
@@ -3257,20 +3253,18 @@ export const geneMock3: Gene = {
       tissue: 'STG',
     },
   ],
-  druggability: [
-    {
-      sm_druggability_bucket: 3,
-      safety_bucket: 4,
-      abability_bucket: 3,
-      pharos_class: 'Tbio',
-      classification:
-        'Targetable by structure: Structurally druggable protein, based on the presence of a druggable pocket in the protein (DrugEBIlity/CanSAR).',
-      safety_bucket_definition:
-        'More than two of: high off target gene expression, cancer driver, essential gene, associated deleterious genetic disorder, HPO phenotype associated gene, or black box warning on clinically used drug.',
-      abability_bucket_definition:
-        'Cell membrane-bound proteins. Highly accessible to antibody-based therapies, but potentially less so than secreted proteins or ECM components.',
-    },
-  ],
+  druggability: {
+    sm_druggability_bucket: 3,
+    safety_bucket: 4,
+    abability_bucket: 3,
+    pharos_class: ['Tbio'],
+    classification:
+      'Targetable by structure: Structurally druggable protein, based on the presence of a druggable pocket in the protein (DrugEBIlity/CanSAR).',
+    safety_bucket_definition:
+      'More than two of: high off target gene expression, cancer driver, essential gene, associated deleterious genetic disorder, HPO phenotype associated gene, or black box warning on clinically used drug.',
+    abability_bucket_definition:
+      'Cell membrane-bound proteins. Highly accessible to antibody-based therapies, but potentially less so than secreted proteins or ECM components.',
+  },
   total_nominations: null,
   is_adi: false,
   is_tep: true,
@@ -3441,20 +3435,18 @@ export const nominatedGeneMock1: Gene = {
     },
   ],
   median_expression: [],
-  druggability: [
-    {
-      sm_druggability_bucket: 3,
-      safety_bucket: 4,
-      abability_bucket: 3,
-      pharos_class: 'Tbio',
-      classification:
-        'Targetable by structure: Structurally druggable protein, based on the presence of a druggable pocket in the protein (DrugEBIlity/CanSAR).',
-      safety_bucket_definition:
-        'More than two of: high off target gene expression, cancer driver, essential gene, associated deleterious genetic disorder, HPO phenotype associated gene, or black box warning on clinically used drug.',
-      abability_bucket_definition:
-        'Cell membrane-bound proteins. Highly accessible to antibody-based therapies, but potentially less so than secreted proteins or ECM components.',
-    },
-  ],
+  druggability: {
+    sm_druggability_bucket: 3,
+    safety_bucket: 4,
+    abability_bucket: 3,
+    pharos_class: ['Tbio'],
+    classification:
+      'Targetable by structure: Structurally druggable protein, based on the presence of a druggable pocket in the protein (DrugEBIlity/CanSAR).',
+    safety_bucket_definition:
+      'More than two of: high off target gene expression, cancer driver, essential gene, associated deleterious genetic disorder, HPO phenotype associated gene, or black box warning on clinically used drug.',
+    abability_bucket_definition:
+      'Cell membrane-bound proteins. Highly accessible to antibody-based therapies, but potentially less so than secreted proteins or ECM components.',
+  },
   total_nominations: 4,
   is_adi: false,
   is_tep: false,
@@ -3544,20 +3536,18 @@ export const noHGNCgeneMock: Gene = {
     },
   ],
   median_expression: [],
-  druggability: [
-    {
-      sm_druggability_bucket: 3,
-      safety_bucket: 4,
-      abability_bucket: 3,
-      pharos_class: 'Tbio',
-      classification:
-        'Targetable by structure: Structurally druggable protein, based on the presence of a druggable pocket in the protein (DrugEBIlity/CanSAR).',
-      safety_bucket_definition:
-        'More than two of: high off target gene expression, cancer driver, essential gene, associated deleterious genetic disorder, HPO phenotype associated gene, or black box warning on clinically used drug.',
-      abability_bucket_definition:
-        'Cell membrane-bound proteins. Highly accessible to antibody-based therapies, but potentially less so than secreted proteins or ECM components.',
-    },
-  ],
+  druggability: {
+    sm_druggability_bucket: 3,
+    safety_bucket: 4,
+    abability_bucket: 3,
+    pharos_class: ['Tbio'],
+    classification:
+      'Targetable by structure: Structurally druggable protein, based on the presence of a druggable pocket in the protein (DrugEBIlity/CanSAR).',
+    safety_bucket_definition:
+      'More than two of: high off target gene expression, cancer driver, essential gene, associated deleterious genetic disorder, HPO phenotype associated gene, or black box warning on clinically used drug.',
+    abability_bucket_definition:
+      'Cell membrane-bound proteins. Highly accessible to antibody-based therapies, but potentially less so than secreted proteins or ECM components.',
+  },
   total_nominations: 4,
   is_adi: false,
   is_tep: false,

--- a/src/server/models/genes.ts
+++ b/src/server/models/genes.ts
@@ -53,7 +53,7 @@ const DruggabilitySchema = new Schema<Druggability>({
   sm_druggability_bucket: { type: Number, required: true },
   safety_bucket: { type: Number, required: true },
   abability_bucket: { type: Number, required: true },
-  pharos_class: { type: String, required: true },
+  pharos_class: { type: [String], required: true },
   classification: { type: String, required: true },
   safety_bucket_definition: { type: String, required: true },
   abability_bucket_definition: { type: String, required: true },
@@ -76,7 +76,7 @@ const GeneSchema = new Schema<Gene>(
     protein_brain_change_studied: { type: Boolean, required: true },
     target_nominations: { type: [TargetNominationSchema], required: true },
     median_expression: { type: [MedianExpressionSchema], required: true },
-    druggability: { type: [DruggabilitySchema], required: true },
+    druggability: { type: DruggabilitySchema, required: true },
     total_nominations: { type: Number, required: true },
     ensembl_info: { type: EnsemblInfoSchema, required: true }
   },


### PR DESCRIPTION
## Changes
- Druggability prop changed from array to object in data version 71
- Pharos class values are now comma deliminated and conditionally displayed
- "No value" logic removed

## Testing
Same method as in AG-1257
Test one gene with pharos class and one without and ensure PHAROS CLASS shows / hides as needed:
http://localhost:8080/genes/ENSG00000000003

![image](https://github.com/user-attachments/assets/357dbab6-d2d9-48c1-867f-03013a263cd0)

http://localhost:8080/genes/ENSG00000002079

![image](https://github.com/user-attachments/assets/ece3e44c-758b-4e5e-bad8-098458e087f2)