### PR TITLE
AG-1630: Deprecate legacy Agora repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,24 @@
 
 # Agora
 
+# ⚠️ DEPRECATED REPOSITORY
+
+**As of April 29, 2025, this repository has been deprecated and is no longer maintained.**
+- No further development will occur in this repository.
+- This repository will not be monitored.
+
+
+## New Repository Location
+
+You can now find this project as part of the monorepo at:
+
+➡**[https://github.com/Sage-Bionetworks/sage-monorepo](https://github.com/Sage-Bionetworks/sage-monorepo)**  
+
+
+For information about the sage-monorepo, see the [sage-monorepo README]([https://github.com/your-org/your-monorepo#readme](https://github.com/Sage-Bionetworks/sage-monorepo/blob/main/README.md)).
+
+
+
 ## Prerequisites
 
 What you need to run this app:


### PR DESCRIPTION
This PR updates the REAME to indicate that Agora has been migrated to the sage-monorepo.